### PR TITLE
[Glance] Ensure messaging driver is set for Glance notifications

### DIFF
--- a/puppet/hieradata/modules/glance.yaml
+++ b/puppet/hieradata/modules/glance.yaml
@@ -60,6 +60,7 @@ glance::notify::rabbitmq::rabbit_port: "%{hiera('osdbmq_rabbitmq_port')}"
 glance::notify::rabbitmq::rabbit_userid: "%{hiera('osdbmq_rabbitmq_user')}"
 glance::notify::rabbitmq::rabbit_password: "%{hiera('osdbmq_rabbitmq_pw')}"
 glance::notify::rabbitmq::rabbit_virtual_host: "%{hiera('osdbmq_rabbitmq_vhost')}"
+glance::notify::rabbitmq::notification_driver: 'messagingv2'
 
 glance::policy::policies:
   glance-context_is_admin:

--- a/puppet/r10k/keystone
+++ b/puppet/r10k/keystone
@@ -8,8 +8,9 @@ mod 'ajcrowe/supervisord'
 mod 'puppetlabs/apt'
 mod 'puppetlabs/concat', '1.2.5'
 mod 'puppetlabs/apache'
+mod 'puppetlabs-inifile'
+mod 'puppetlabs-mysql'
 
-mod 'openstack/neutron'
 mod 'openstack/keystone',
     :git    => "https://github.com/openstack/puppet-keystone.git",
     :branch => "master"
@@ -17,10 +18,6 @@ mod 'openstack/nova'
 mod 'openstack/openstacklib',
     :git    => "https://github.com/openstack/puppet-openstacklib.git",
     :branch => "master"
-mod 'openstack/vswitch'
-mod 'openstack/cinder'
 mod 'openstack/oslo',
     :git    => "https://github.com/openstack/puppet-oslo.git",
     :branch => "master"
-mod 'puppetlabs-inifile'
-mod 'puppetlabs-mysql'


### PR DESCRIPTION
The `::glance::notify::rabbitmq` class doesn't actually set a messaging
driver value by default, so notifications aren't properly emitted.  This
commit fixes that.

Bonus cleanup of the r10k file for Keystone which removes some redundant
modules.