### PR TITLE
[Cinder][Glance] Bump default worker threads

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,36 @@
+DOMAIN=sal01.datacentred.co.uk
+RELEASE=mitaka
+VCSREF=$(shell git rev-parse --short HEAD)
+DATE=$(shell date --rfc-3339=date)
+REGISTRY=registry.datacentred.services:5000
+
+all:	keystone glance cinder horizon
+.PHONY: all keystone glance cinder horizon clean
+
+keystone:
+		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
+		rocker build -f common/Rockerfile --vars common/common.yaml --var EXPOSE="5000 35357" \
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/keystone:$(RELEASE)-$(VCSREF)
+		
+glance:
+		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
+		NAME="glance" rocker build -f common/Rockerfile --vars common/common.yaml --var EXPOSE="9191 9292" \
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=glance:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+		
+cinder:
+		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
+		rocker build -f common/Rockerfile --vars common/common.yaml --var EXPOSE="8776" \
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+		
+horizon:
+		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
+		rocker build -f common/Rockerfile --vars common/common.yaml --var EXPOSE="80" \
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+
+clean:
+		docker rmi $$(docker images -f "dangling=true" -q)
+		docker rm -v $$(docker ps -a -q -f status=exited)

--- a/common/Rockerfile
+++ b/common/Rockerfile
@@ -18,11 +18,15 @@ COPY puppet/r10k/{{ .ROLE }} /Puppetfile
 COPY {{ .COPY.profile }}
 COPY {{ .COPY.defaultpp }}
 
-RUN  {{ .RUN.puppet_apply }}
+RUN {{ .RUN.puppet_apply }}
 
 CMD {{ .CMD }}
 
 EXPOSE {{ .EXPOSE }}
 TAG {{ .TAG }}
+
+LABEL org.label-schema.build-date={{ .Env.DATE }}
+LABEL org.label-schema.name={{ .Env.NAME }}
+LABEL org.label-schema.vcs-ref={{ .Env.VCSREF }}
 
 # vim:ts=4:sw=4:et:ft=Dockerfile

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -28,6 +28,7 @@ RUN:
     puppet apply /default.pp --verbose --show_diff  --summarize --hiera_config=/hieradata/hiera.yaml && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
 COPY:
   profile: 'puppet/modules/profile /profile'
   defaultpp: 'puppet/default.pp /'

--- a/puppet/hieradata/modules/cinder.yaml
+++ b/puppet/hieradata/modules/cinder.yaml
@@ -33,7 +33,7 @@ cinder::log_file: "%{::os_service_default}"
 cinder::storage_availability_zone: 'Production'
 cinder::default_availability_zone: 'Production'
 
-cinder::api::service_workers: '4'
+cinder::api::service_workers: '8'
 cinder::api::os_region_name: 'sal01'
 cinder::api::default_volume_type: 'Ceph'
 cinder::api::nova_catalog_info: 'compute:nova:publicURL'

--- a/puppet/hieradata/modules/glance.yaml
+++ b/puppet/hieradata/modules/glance.yaml
@@ -25,6 +25,7 @@ glance::api::debug: false
 glance::api::use_stderr: true
 glance::api::log_dir: "%{::os_service_default}"
 glance::api::log_file: "%{::os_service_default}"
+glance::api::workers: '8'
 
 glance::registry::authtoken::username: 'glance'
 glance::registry::authtoken::password: "%{hiera('keystone_glance_password')}"
@@ -44,6 +45,7 @@ glance::registry::debug: false
 glance::registry::use_stderr: true
 glance::registry::log_dir: "%{::os_service_default}"
 glance::registry::log_file: "%{::os_service_default}"
+glance::registry::workers: '8'
 
 glance::registry::sync_db: false
 


### PR DESCRIPTION
Worker threadcount for both Cinder and Glance should be increased to
match the number of physical cores installed on the server.  In our case
that's 8, so these updated images contain that configuration.

Bonus Makefile for generating images in one command.