### PR TITLE
Set release to 'Liberty' instead of 'Mitaka'

### DIFF
--- a/puppet/hieradata/modules/apt.yaml
+++ b/puppet/hieradata/modules/apt.yaml
@@ -2,7 +2,7 @@
 apt::sources:
   cloudarchive_mirror:
     location: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
-    release: 'trusty-updates/mitaka'
+    release: 'trusty-updates/liberty'
     repos: 'main'
     key:
       id: '391A9AA2147192839E9DB0315EDB1B62EC4926EA'


### PR DESCRIPTION
This only affects containers based on `ubuntu:14.04`, which will just
be Nova and Neutron for now.

This is required to build a Liberty-based Nova control container as
it's not possible to an n+2 upgrade of this service.