### PR TITLE
[Horizon] Use Apache Event MPM

### DIFF
--- a/puppet/hieradata/role/horizon.yaml
+++ b/puppet/hieradata/role/horizon.yaml
@@ -11,3 +11,5 @@ service:
     'stderr_logfile_maxbytes': '0'
 
 branding::horizon::release: 'mitaka'
+
+apache::mpm_module: 'event'


### PR DESCRIPTION
Using prefork, yet event is default in Apache now.
Sets MPM to 'event' as per https://httpd.apache.org/docs/current/mod/event.html