### PR TITLE
[Keystone] Use Apache Event MPM

### DIFF
--- a/puppet/hieradata/role/keystone.yaml
+++ b/puppet/hieradata/role/keystone.yaml
@@ -11,3 +11,5 @@ service:
     'stderr_logfile_maxbytes': '0'
 
 keystone_db_user: 'keystone'
+
+apache::mpm_module: 'event'


### PR DESCRIPTION
Using prefork, yet event is default in Apache now.
Sets MPM to 'event' as per https://httpd.apache.org/docs/current/mod/event.html