### PR TITLE
Use ::dummy_service by default for all image builds

### DIFF
--- a/puppet/hieradata/common.yaml
+++ b/puppet/hieradata/common.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - '::apt'
+  - '::dummy_service'
   - '::supervisord'
   - '::profile::util::prompt'
 

--- a/puppet/r10k/cinder
+++ b/puppet/r10k/cinder
@@ -2,19 +2,15 @@ forge 'https://forgeapi.puppetlabs.com'
 
 mod 'puppetlabs-stdlib',
     :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-
 mod 'puppetlabs/ntp',
     :git => "https://github.com/puppetlabs/puppetlabs-ntp.git"
-
-mod 'markhellewell/aptcacherng'
 mod 'puppetlabs/apt'
 mod 'puppetlabs/apache'
 mod 'ajcrowe/supervisord'
 mod 'puppetlabs/concat', '1.2.5'
-mod 'puppetlabs/mysql'
 mod 'puppetlabs-dummy_service', '0.2.0'
-
 mod 'puppetlabs/inifile'
+mod 'puppetlabs/mysql'
 
 mod 'openstack/cinder',
     :git    => "https://github.com/openstack/puppet-cinder",

--- a/puppet/r10k/glance
+++ b/puppet/r10k/glance
@@ -2,19 +2,15 @@ forge 'https://forgeapi.puppetlabs.com'
 
 mod 'puppetlabs-stdlib',
     :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-
 mod 'puppetlabs/ntp',
     :git => "https://github.com/puppetlabs/puppetlabs-ntp.git"
-
-mod 'markhellewell/aptcacherng'
 mod 'puppetlabs/apt'
 mod 'puppetlabs/apache'
 mod 'ajcrowe/supervisord'
 mod 'puppetlabs/concat', '1.2.5'
-mod 'puppetlabs/mysql'
 mod 'puppetlabs-dummy_service', '0.2.0'
-
 mod 'puppetlabs/inifile'
+mod 'puppetlabs/mysql'
 
 mod 'openstack/glance',
     :git    => "https://github.com/openstack/puppet-glance",

--- a/puppet/r10k/horizon
+++ b/puppet/r10k/horizon
@@ -2,19 +2,17 @@ forge 'https://forgeapi.puppetlabs.com'
 
 mod 'puppetlabs-stdlib',
     :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-
 mod 'puppetlabs/ntp',
     :git => "https://github.com/puppetlabs/puppetlabs-ntp.git"
-
-mod 'datacentred/branding',
-    :git => "https://dc_jenkins:27485be45693278ac9be41d4540c8ac4f1adc6b7@github.com/datacentred/branding.git",
-    :branch => "mitaka-location-fix"
-
-mod 'markhellewell/aptcacherng'
 mod 'puppetlabs/apt'
 mod 'puppetlabs/apache'
 mod 'ajcrowe/supervisord'
 mod 'puppetlabs/concat', '1.2.5'
+mod 'puppetlabs-dummy_service', '0.2.0'
+
+mod 'datacentred/branding',
+    :git => "https://dc_jenkins:27485be45693278ac9be41d4540c8ac4f1adc6b7@github.com/datacentred/branding.git",
+    :branch => "mitaka-location-fix"
 
 mod 'openstack/horizon',
     :git    => "https://github.com/datacentred/puppet-horizon.git",

--- a/puppet/r10k/keystone
+++ b/puppet/r10k/keystone
@@ -8,6 +8,7 @@ mod 'ajcrowe/supervisord'
 mod 'puppetlabs/apt'
 mod 'puppetlabs/concat', '1.2.5'
 mod 'puppetlabs/apache'
+mod 'puppetlabs-dummy_service', '0.2.0'
 mod 'puppetlabs-inifile'
 mod 'puppetlabs-mysql'
 

--- a/puppet/r10k/nova
+++ b/puppet/r10k/nova
@@ -8,6 +8,7 @@ mod 'ajcrowe/supervisord'
 mod 'puppetlabs/apt'
 mod 'puppetlabs/concat', '1.2.5'
 mod 'puppetlabs-inifile'
+mod 'puppetlabs-dummy_service', '0.2.0'
 mod 'puppetlabs-mysql'
 
 mod 'openstack/glance',


### PR DESCRIPTION
And remove reference to the `aptcacherng` module which isn't actually used anywhere.