### PR TITLE
[Glance] Reduce thread count, fix incorrect domain

### DIFF
--- a/puppet/hieradata/domains/sal01.datacentred.co.uk/modules/glance.yaml
+++ b/puppet/hieradata/domains/sal01.datacentred.co.uk/modules/glance.yaml
@@ -4,7 +4,8 @@ glance::api::known_stores:
     - http
     - file
 glance::api::default_store: 'rbd'
-glance::api::workers: '8'
+glance::api::workers: '4'
+glance::api::os_region_name: 'sal01'
 glance::registry::authtoken::region_name: 'sal01'
 
 glance::notify::rabbitmq::rabbit_hosts:

--- a/puppet/hieradata/domains/vagrant.test/modules/glance.yaml
+++ b/puppet/hieradata/domains/vagrant.test/modules/glance.yaml
@@ -4,6 +4,9 @@ glance::api::known_stores:
     - file
 glance::api::default_store: 'file'
 glance::api::workers: '2'
+glance::api::os_region_name: 'vagrant'
 glance::registry::authtoken::region_name: 'vagrant'
+
+glance::backend::rbd::multi_store: true
 
 glance::notify::rabbitmq::rabbit_host: osdbmq0.%{::domain}


### PR DESCRIPTION
This commit halves the thread count in an attempt to curtail resource
contention in Production.

It also fixes the domain being set incorrectly, and makes a couple of
other changes so that things work a bit better in Vagrant.