### PR TITLE
[Workflow] Fix image labelling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,5 +47,4 @@ horizon:
 		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
 
 clean:
-		docker rmi $$(docker images -f "dangling=true" -q)
-		docker rm -v $$(docker ps -a -q -f status=exited)
+		yes | docker image prune

--- a/common/Rockerfile
+++ b/common/Rockerfile
@@ -23,11 +23,12 @@ RUN {{ .RUN.puppet_apply }}
 CMD {{ .CMD }}
 
 EXPOSE {{ .EXPOSE }}
-TAG {{ .TAG }}
 
-LABEL org.label-schema.build-date={{ .Env.DATE }}
-LABEL org.label-schema.name={{ .Env.NAME }}
-LABEL org.label-schema.vcs-ref={{ .Env.VCSREF }}
-LABEL org.label-schema.vcs-url="https://github.com/datacentred/docker"
+LABEL org.label-schema.build-date={{ .Env.DATE }} \
+      org.label-schema.name={{ .Env.NAME }} \
+      org.label-schema.vcs-ref={{ .Env.VCSREF }} \
+      org.label-schema.vcs-url="https://github.com/datacentred/docker"
+
+TAG {{ .TAG }}
 
 # vim:ts=4:sw=4:et:ft=Dockerfile


### PR DESCRIPTION
This minor change ensures that the labels defined in the Rockerfile
actually make it into the final image artefact.  As a bonus, you don't
end up with that mysterious dangling image and the end of every build.