### PR TITLE
[Cinder] Halve the number of Cinder API workers

### DIFF
--- a/puppet/hieradata/domains/sal01.datacentred.co.uk/modules/cinder.yaml
+++ b/puppet/hieradata/domains/sal01.datacentred.co.uk/modules/cinder.yaml
@@ -8,4 +8,4 @@ cinder::rabbit_hosts:
  - osdbmq2.%{::domain}
 
 cinder::rabbit_ha_queues: true
-cinder::api::service_workers: '8'
+cinder::api::service_workers: '4'


### PR DESCRIPTION
Reduce memory pressure across control nodes by halving the number of API
workers deployed for Cinder.