### PR TITLE
[Glance] Patch RBD driver to work around bug in Ceph 10.2.3

### DIFF
--- a/puppet/modules/profile/manifests/openstack/glance.pp
+++ b/puppet/modules/profile/manifests/openstack/glance.pp
@@ -13,4 +13,18 @@ class profile::openstack::glance {
 
   Class[::ceph] -> Class['::glance::backend::rbd']
 
+  # TODO: Remove this hack once packages for Ceph 10.2.4 are
+  # available - see https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/1625489
+  #
+  package { 'python-glance-store':
+    ensure => 'present',
+  } ->
+  file { 'rbd.py':
+    path   => '/usr/lib/python2.7/dist-packages/glance_store/_drivers/rbd.py',
+    source => 'puppet:///modules/dc_openstack/rbd.py',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+  }
+
 }

--- a/puppet/r10k/glance
+++ b/puppet/r10k/glance
@@ -26,3 +26,6 @@ mod 'openstack/keystone',
     :branch => "master"
 
 mod 'spjmurray/ceph', '1.5.1'
+
+mod 'datacentred/dc_openstack',
+    :git => "https://github.com/datacentred/dc_openstack"


### PR DESCRIPTION
Build a new Glance Docker image featuring a workaround for this bug in Ceph:

http://tracker.ceph.com/issues/17310

It uses this OpenStack patch to Glance's RBD driver as an inspiration for the
workaround:

https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/1625489

The actual patched file itself is here:

https://github.com/datacentred/dc_openstack/blob/master/files/rbd.py

Fixes PD-2827.