### PR TITLE
[Cinder] Track minor changes in upstream configuration options

### DIFF
--- a/puppet/hieradata/modules/cinder.yaml
+++ b/puppet/hieradata/modules/cinder.yaml
@@ -16,7 +16,7 @@ cinder::rabbit_userid: "%{hiera('osdbmq_rabbitmq_user')}"
 cinder::rabbit_password: "%{hiera('osdbmq_rabbitmq_pw')}"
 cinder::rabbit_virtual_host: "%{hiera('osdbmq_rabbitmq_vhost')}"
 
-cinder::host: "%{hiera('os_api_host')}"
+cinder::backend_host: "%{hiera('os_api_host')}"
 cinder::enable_v1_api: false
 cinder::enable_v2_api: true
 cinder::enable_v3_api: true

--- a/puppet/modules/profile/manifests/openstack/cinder.pp
+++ b/puppet/modules/profile/manifests/openstack/cinder.pp
@@ -13,7 +13,6 @@ class profile::openstack::cinder {
   include ::cinder::glance
   include ::cinder::quota
   include ::cinder::volume
-  include ::cinder::volume::rbd
   include ::cinder::backends
   include ::cinder::ceilometer
   include ::cinder::config


### PR DESCRIPTION
The Cinder image currently fails to build due to a couple of
configuration changes upstream.  This commit updates a one option and
removes a depreciated class.