### PR TITLE
[Glance] Enables property protection

### DIFF
--- a/puppet/modules/profile/manifests/openstack/glance.pp
+++ b/puppet/modules/profile/manifests/openstack/glance.pp
@@ -27,4 +27,27 @@ class profile::openstack::glance {
     mode   => '0644',
   }
 
+  file { '/usr/local/etc/glance/':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  file { 'property_pr_rules':
+    path   => '/usr/local/etc/glance/property_pr_rules',
+    source => 'puppet:///modules/dc_openstack/property_pr_rules',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+  }
+
+  glance_api_config { 'DEFAULT/property_protection_file' :
+    value => '/usr/local/etc/glance/property_pr_rules',
+  }
+
+  glance_api_config { 'DEFAULT/property_protection_rule_format' :
+    value => 'roles',
+  }
+
 }


### PR DESCRIPTION
It prevents non-admin users from being able to read, modify or delete the
oswindows property used for scheduling windows instances on the right hypervisor.

PD-2075