### PR TITLE
[Nova] Fix keystone_authtoken options for Liberty

### DIFF
--- a/puppet/modules/profile/manifests/openstack/nova.pp
+++ b/puppet/modules/profile/manifests/openstack/nova.pp
@@ -12,6 +12,13 @@ class profile::openstack::nova {
   include ::nova::scheduler::filter
   include ::nova::vncproxy
 
+  nova_config {
+    'keystone_authtoken/auth_plugin':       value => 'password';
+    'keystone_authtoken/admin_user':        value => 'nova';
+    'keystone_authtoken/admin_tenant_name': value => 'services';
+    'keystone_authtoken/admin_password':    value => hiera('keystone_nova_password');
+  }
+
   package { 'iptables':
     ensure => present,
   }->


### PR DESCRIPTION
The Mitaka branch of the module we're using doesn't quite set the right
selection of options in order for authentication via Keystone to be
successful.

Fix this by using the `nova_config` type directly to set the relevant
missing options.

Can probably be removed just as soon as we're on at least Mitaka.