### PR TITLE
Revert "Add another set of missing config options (#35)"

### DIFF
--- a/puppet/modules/profile/manifests/openstack/nova.pp
+++ b/puppet/modules/profile/manifests/openstack/nova.pp
@@ -26,10 +26,6 @@ class profile::openstack::nova {
     'neutron/admin_tenant_name':            value => 'services';
     'neutron/admin_password':               value => hiera('keystone_neutron_password');
     'neutron/identity_uri':                 value => "https://${hiera('os_api_host')}:35357";
-    'neutron/url':                          value => "https://${hiera('os_api_host')}:9696";
-    'neutron/auth_url':                     value => "https://${hiera('os_api_host')}:35357";
-    'neutron/username':                     value => 'neutron';
-    'neutron/password':                     value => hiera('keystone_neutron_password');
   }
 
   package { 'iptables':


### PR DESCRIPTION
These options are already set and handled by the `puppet-nova` module.
Including these and attempting to build a container image results in
duplicate declaration errors.

This reverts commit b9afbd416762edfb8241ab111c7e4b183bbcc79a.