### PR TITLE
[Nova] Add missing options and new / fixed Nova scheduler

### DIFF
--- a/puppet/hieradata/modules/nova.yaml
+++ b/puppet/hieradata/modules/nova.yaml
@@ -39,6 +39,8 @@ nova::api::sync_db_api: false
 nova::api::enable_instance_password: true
 nova::api::neutron_metadata_proxy_shared_secret: "%{hiera('neutron_metadata_secret')}"
 nova::api::default_floating_pool: 'external'
+nova::api::secure_proxy_ssl_header: 'X-Forwarded-Proto'
+nova::api::compute_link_prefix: 'https://compute.datacentred.io:8774/'
 
 nova::network::neutron::neutron_url: "https://%{hiera('os_api_host')}:9696"
 nova::network::neutron::neutron_auth_plugin: 'password'

--- a/puppet/modules/profile/manifests/openstack/nova.pp
+++ b/puppet/modules/profile/manifests/openstack/nova.pp
@@ -38,4 +38,13 @@ class profile::openstack::nova {
     mode    => '0770',
   }
 
+  file { '/usr/lib/python2.7/dist-packages/nova/scheduler/filters/aggregate_image_properties_isolation_dc.py':
+    ensure  => present,
+    content => file('dc_openstack/aggregate_image_properties_isolation_dc.py'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require =>  Package['python-nova'],
+  }
+
 }

--- a/puppet/r10k/nova
+++ b/puppet/r10k/nova
@@ -30,3 +30,6 @@ mod 'openstack/cinder',
 mod 'openstack/nova',
     :git => "https://github.com/openstack/puppet-nova",
     :branch => "stable/newton"
+
+mod 'datacentred/dc_openstack',
+    :git => "https://github.com/datacentred/dc_openstack"


### PR DESCRIPTION
This commit moves a couple of options into Hiera.  These were previously
handled in the profile class, but they are now catered for in the
upsteam Puppet module.

This also bundles the 'fixed' Nova image properties scheduler filter.