### PR TITLE
[Nova] Liberty configuration fixes

### DIFF
--- a/puppet/hieradata/modules/nova.yaml
+++ b/puppet/hieradata/modules/nova.yaml
@@ -20,6 +20,7 @@ nova::use_syslog: true
 nova::log_dir: "%{::os_service_default}"
 nova::upgrade_level_compute: 'kilo'
 nova::upgrade_level_conductor: 'kilo'
+nova::upgrade_level_scheduler: 'kilo'
 
 nova::keystone::authtoken::username: 'nova'
 nova::keystone::authtoken::password: "%{hiera('keystone_nova_password')}"
@@ -41,18 +42,22 @@ nova::api::neutron_metadata_proxy_shared_secret: "%{hiera('neutron_metadata_secr
 nova::api::default_floating_pool: 'external'
 nova::api::secure_proxy_ssl_header: 'X-Forwarded-Proto'
 nova::api::compute_link_prefix: 'https://compute.datacentred.io:8774/'
+nova::api::admin_password: "%{hiera('keystone_nova_password')}"
+nova::api::auth_uri: "https://%{hiera('os_api_host')}:5000/"
+nova::api::identity_uri: "https://%{hiera('os_api_host')}:35357/"
 
 nova::network::neutron::neutron_url: "https://%{hiera('os_api_host')}:9696"
 nova::network::neutron::neutron_auth_plugin: 'password'
 nova::network::neutron::neutron_username: 'neutron'
 nova::network::neutron::neutron_password: "%{hiera('keystone_neutron_password')}"
 nova::network::neutron::neutron_auth_url: "https://%{hiera('os_api_host')}:35357/v3"
-nova::network::neutron::neutron_region_name: "%{hiera('os_region')}"
+nova::network::neutron::neutron_region_name: "%{hiera('os_region_name')}"
 nova::network::neutron::vif_plugging_is_fatal: false
 nova::network::neutron::vif_plugging_timeout: '0'
 nova::network::neutron::firewall_driver: 'nova.virt.firewall.NoopFirewallDriver'
 nova::network::neutron::network_api_class: 'nova.network.neutronv2.api.API'
 nova::network::neutron::security_group_api: 'neutron'
+nova::network::neutron::dhcp_domain: 'datacentred.io'
 
 nova::cert::enabled: true
 nova::conductor::enabled: true
@@ -73,6 +78,9 @@ nova::scheduler::filter::scheduler_default_filters:
   - ServerGroupAntiAffinityFilter
   - ServerGroupAffinityFilter
   - IsolatedHostsFilter
+nova::scheduler::filter::ram_allocation_ratio: 0.9
+nova::scheduler::filter::cpu_allocation_ratio: 8.0
+nova::scheduler::filter::scheduler_host_subset_size: '10'
 
 nova::vncproxy::common::vncproxy_host: "%{hiera('os_api_host')}"
 nova::vncproxy::common::vncproxy_protocol: 'https'

--- a/puppet/modules/profile/manifests/openstack/nova.pp
+++ b/puppet/modules/profile/manifests/openstack/nova.pp
@@ -15,17 +15,13 @@ class profile::openstack::nova {
   # TODO: Remove these hacky workarounds once we're at a version of OpenStack that's
   # properly supported by puppet-nova
   nova_config {
-    'default/network_api_class':            value => 'nova.network.neutronv2.api.API';
-    'default/linuxnet_interface_driver':    value => 'nova.network.linux_net.LinuxBridgeInterfaceDriver';
-    'keystone_authtoken/auth_plugin':       value => 'password';
-    'keystone_authtoken/admin_user':        value => 'nova';
-    'keystone_authtoken/admin_tenant_name': value => 'services';
-    'keystone_authtoken/admin_password':    value => hiera('keystone_nova_password');
-    'neutron/auth_plugin':                  value => 'password';
-    'neutron/admin_user':                   value => 'neutron';
-    'neutron/admin_tenant_name':            value => 'services';
-    'neutron/admin_password':               value => hiera('keystone_neutron_password');
-    'neutron/identity_uri':                 value => "https://${hiera('os_api_host')}:35357";
+    'keystone_authtoken/auth_url':            value => "https://${hiera('os_api_host')}:35357";
+    'keystone_authtoken/auth_plugin':         value => 'password';
+    'keystone_authtoken/project_domain_name': value => 'default';
+    'keystone_authtoken/user_domain_name':    value => 'default';
+    'keystone_authtoken/project_name':        value => 'services';
+    'keystone_authtoken/username':            value => 'nova';
+    'keystone_authtoken/password':            value => hiera('keystone_nova_password');
   }
 
   package { 'iptables':

--- a/puppet/r10k/nova
+++ b/puppet/r10k/nova
@@ -11,25 +11,11 @@ mod 'puppetlabs-inifile'
 mod 'puppetlabs-dummy_service', '0.2.0'
 mod 'puppetlabs-mysql'
 mod 'puppetlabs-dummy_service', '0.2.0'
-
-mod 'openstack/glance',
-    :git    => "https://github.com/openstack/puppet-glance"
-
-mod 'openstack/openstacklib',
-    :git    => "https://github.com/openstack/puppet-openstacklib"
-
-mod 'openstack/oslo',
-    :git    => "https://github.com/openstack/puppet-oslo"
-
-mod 'openstack/keystone',
-    :git    => "https://github.com/openstack/puppet-keystone"
-
-mod 'openstack/cinder',
-    :git    => "https://github.com/openstack/puppet-cinder"
-
-mod 'openstack/nova',
-    :git => "https://github.com/openstack/puppet-nova",
-    :branch => "stable/newton"
+mod 'openstack-nova', '8.0.1'
+mod 'openstack-keystone', '8.0.1'
+mod 'openstack-glance', '8.0.1'
+mod 'openstack-cinder', '8.0.1'
+mod 'openstack-openstacklib', '8.0.1'
 
 mod 'datacentred/dc_openstack',
     :git => "https://github.com/datacentred/dc_openstack"


### PR DESCRIPTION
This commit switches the version of the Puppet module used to configure
Nova to the specific Liberty release issued via the Forge, thus ensuring
better compatibility with some of the options.

It also adds and amends a few options that were missing.