### PR TITLE
[Cinder] Disable Volume Cleaning

### DIFF
--- a/puppet/hieradata/modules/cinder.yaml
+++ b/puppet/hieradata/modules/cinder.yaml
@@ -38,6 +38,8 @@ cinder::scheduler::manage_service: false
 
 cinder::glance::glance_api_servers: "https://%{hiera('os_api_host')}:9292"
 
+cinder::volume::volume_clear: 'none'
+
 cinder::volume::rbd::rbd_pool: 'cinder.volumes'
 cinder::volume::rbd::rbd_user: 'cinder'
 cinder::volume::rbd::rbd_secret_uuid: '42991612-85dc-42e4-ae3c-49cf07e98b70'


### PR DESCRIPTION
 Cinder may be cleaning the volume unnecessarily on deletion. As we're using Ceph, it's not possible to remap older customer data when a new volume is created (unlike local block storage). This would need to be done if we used local storage (or at least set very low size to flatten) but as we're not we should disable it. Set to `volume_clear=none`

Addresses PD-2971