### PR TITLE
[Monitoring] Enable healtcheck glance/keystone/nova

### DIFF
--- a/puppet/hieradata/role/glance.yaml
+++ b/puppet/hieradata/role/glance.yaml
@@ -26,3 +26,93 @@ ceph::keys:
   /etc/ceph/ceph.client.cinder.keyring:
     user: 'client.cinder'
     key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAivwvH1tZTSaqnfesNg9LI0ehzXgfVCqJTbAZeXzx3gFzib5PmEyJ3AV8t/P4F5QcAf7cNSdLCTfGuTo8dcFAlVUS1VfpCtwQ54vWiz+ZLrHKjP2/GW2bD7dAWiveIhrH+y+RWE+uSswAP26hdIxllwDbC2ctmBt8XDyXQMxrOfydXTxmr8+E2HWGDMC6WvTBc6zupVvw3PSpd+IWfuX1pGTzkN4990ZUpjLn6RTLrYrkmzvprJM4z2RtMPInEg9o3JO1gJGvzoA4tY9q/OfC/mZ7v+JAhGnJGRoBgjhQaL8jVfdYGTQMmZEbhTd0FCGoOy/qq6KItKjeFIvGuMUaFDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBryaL7Gq8wKzUbglH8RCw0gDBrZwsCnFy/TNdrgp/80hCWkEeBVQ8VKEIhJJCBDcxSpzlFDx24VLUpeyk5gAH8K9M=]
+
+settings:
+  line1:
+    section: 'filter:healthcheck'
+    setting: 'paste.filter_factory'
+    value: 'oslo_middleware:Healthcheck.factory'
+    path: '/etc/glance/glance-api-paste.ini'
+  line2:
+    section: 'filter:healthcheck'
+    setting: 'backends'
+    value: 'disable_by_file'
+    path: '/etc/glance/glance-api-paste.ini'
+  line3:
+    section: 'filter:healthcheck'
+    setting: 'disable_by_file_path'
+    value: '/etc/glance/healthcheck_disable'
+    path: '/etc/glance/glance-api-paste.ini'
+  line4:
+    section: 'pipeline:glance-api'
+    setting: 'pipeline'
+    value: 'healthcheck cors versionnegotiation osprofiler unauthenticated-context rootapp'
+    path: '/etc/glance/glance-api-paste.ini'
+  line5:
+    section: 'pipeline:glance-api-caching'
+    setting: 'pipeline'
+    value: 'healthcheck cors versionnegotiation osprofiler unauthenticated-context cache rootapp'
+    path: '/etc/glance/glance-api-paste.ini'
+  line6:
+    section: 'pipeline:glance-api-cachemanagement'
+    setting: 'pipeline'
+    value: 'healthcheck cors versionnegotiation osprofiler unauthenticated-context cache cachemanage rootapp'
+    path: '/etc/glance/glance-api-paste.ini'
+  line7:
+    section: 'pipeline:glance-api-keystone'
+    setting: 'pipeline'
+    value: 'healthcheck cors versionnegotiation osprofiler authtoken context  rootapp'
+    path: '/etc/glance/glance-api-paste.ini'
+  line8:
+    section: 'pipeline:glance-api-keystone+caching'
+    setting: 'pipeline'
+    value: 'healthcheck cors versionnegotiation osprofiler authtoken context cache rootapp'
+    path: '/etc/glance/glance-api-paste.ini'
+  line9:
+    section: 'pipeline:glance-api-keystone+cachemanagement'
+    setting: 'pipeline'
+    value: 'healthcheck cors versionnegotiation osprofiler authtoken context cache cachemanage rootapp'
+    path: '/etc/glance/glance-api-paste.ini'
+  line10:
+    section: 'pipeline:glance-api-trusted-auth'
+    setting: 'pipeline'
+    value: 'healthcheck cors versionnegotiation osprofiler context rootapp'
+    path: '/etc/glance/glance-api-paste.ini'
+  line11:
+    section: 'pipeline:glance-api-trusted-auth+cachemanagement'
+    setting: 'pipeline'
+    value: 'healthcheck cors versionnegotiation osprofiler context cache cachemanage rootapp'
+    path: '/etc/glance/glance-api-paste.ini'
+  line20:
+    section: 'filter:healthcheck'
+    setting: 'paste.filter_factory'
+    value: 'oslo_middleware:Healthcheck.factory'
+    path: '/etc/glance/glance-registry-paste.ini'
+  line20:
+    section: 'filter:healthcheck'
+    setting: 'backends'
+    value: 'disable_by_file'
+    path: '/etc/glance/glance-registry-paste.ini'
+  line20:
+    section: 'filter:healthcheck'
+    setting: 'disable_by_file_path'
+    value: '/etc/glance/healthcheck_disable'
+    path: '/etc/glance/glance-registry-paste.ini'
+  line20:
+    section: 'pipeline:glance-registry-trusted-auth'
+    setting: 'pipeline'
+    value: 'healthcheck osprofiler context registryapp'
+    path: '/etc/glance/glance-registry-paste.ini'
+  line20:
+    section: 'pipeline:glance-registry'
+    setting: 'pipeline'
+    value: 'healthcheck osprofiler unauthenticated-context registryapp'
+    path: '/etc/glance/glance-registry-paste.ini'
+  line20:
+    section: 'pipeline:glance-registry-keystone'
+    setting: 'pipeline'
+    value: 'healthcheck osprofiler authtoken context registryapp'
+    path: '/etc/glance/glance-registry-paste.ini'
+
+dc_openstack::ini::defaults:
+  require: Package[python-glance-store]

--- a/puppet/hieradata/role/keystone.yaml
+++ b/puppet/hieradata/role/keystone.yaml
@@ -13,3 +13,41 @@ service:
 keystone_db_user: 'keystone'
 
 apache::mpm_module: 'event'
+
+settings:
+  line1:
+    section: 'filter:healthcheck'
+    setting: 'paste.filter_factory'
+    value: 'oslo_middleware:Healthcheck.factory'
+  line2:
+    section: 'filter:healthcheck'
+    setting: 'backends'
+    value: 'disable_by_file'
+  line3:
+    section: 'filter:healthcheck'
+    setting: 'disable_by_file_path'
+    value: '/etc/keystone/healthcheck_disable'
+  line4:
+    section: 'pipeline:public_api'
+    setting: 'pipeline'
+    value: 'healthcheck cors sizelimit url_normalize request_id admin_token_auth build_auth_context token_auth json_body ec2_extension public_service'
+  line5:
+    section: 'pipeline:admin_api'
+    setting: 'pipeline'
+    value: 'healthcheck cors sizelimit url_normalize request_id admin_token_auth build_auth_context token_auth json_body ec2_extension s3_extension admin_service'
+  line6:
+    section: 'pipeline:api_v3'
+    setting: 'pipeline'
+    value: 'healthcheck cors sizelimit url_normalize request_id admin_token_auth build_auth_context token_auth json_body ec2_extension_v3 s3_extension service_v3'
+  line7:
+    section: 'pipeline:public_version_api'
+    setting: 'pipeline'
+    value: 'healthcheck cors sizelimit url_normalize public_version_service'
+  line8:
+    section: 'pipeline:admin_version_api'
+    setting: 'pipeline'
+    value: 'healthcheck cors sizelimit url_normalize admin_version_service'
+
+dc_openstack::ini::defaults:
+  path: '/etc/keystone/keystone-paste.ini'
+  require: Package[keystone]

--- a/puppet/hieradata/role/nova.yaml
+++ b/puppet/hieradata/role/nova.yaml
@@ -45,3 +45,29 @@ nova_db_user: 'nova'
 
 nova_api_db: 'nova_api'
 nova_api_db_user: 'nova_api'
+
+settings:
+  line1:
+    section: 'filter:healthcheck'
+    setting: 'paste.filter_factory'
+    value: 'oslo_middleware:Healthcheck.factory'
+  line2:
+    section: 'filter:healthcheck'
+    setting: 'backends'
+    value: 'disable_by_file'
+  line3:
+    section: 'filter:healthcheck'
+    setting: 'disable_by_file_path'
+    value: '/etc/nova/healthcheck_disable'
+  line4:
+    section: 'pipeline:meta'
+    setting: 'pipeline'
+    value: 'healthcheck cors metaapp'
+  line5:
+    section: 'pipeline:oscomputeversions'
+    setting: 'pipeline'
+    value: 'healthcheck faultwrap oscomputeversionapp'
+
+dc_openstack::ini::defaults:
+  require: Package[python-nova]
+  path: /etc/nova/api-paste.ini

--- a/puppet/modules/profile/manifests/openstack/glance.pp
+++ b/puppet/modules/profile/manifests/openstack/glance.pp
@@ -2,6 +2,7 @@
 # == Class: profile::openstack::glance
 #
 class profile::openstack::glance {
+  include ::dc_openstack::ini
   include ::glance::api
   include ::glance::api::authtoken
   include ::glance::registry

--- a/puppet/modules/profile/manifests/openstack/keystone.pp
+++ b/puppet/modules/profile/manifests/openstack/keystone.pp
@@ -2,6 +2,7 @@
 #
 class profile::openstack::keystone {
 
+  include ::dc_openstack::ini
   include ::keystone
   include ::keystone::wsgi::apache
 

--- a/puppet/modules/profile/manifests/openstack/nova.pp
+++ b/puppet/modules/profile/manifests/openstack/nova.pp
@@ -2,6 +2,7 @@
 # ==Class: ::profile::openstack::nova
 #
 class profile::openstack::nova {
+  include ::dc_openstack::ini
   include ::nova
   include ::nova::api
   include ::nova::network::neutron

--- a/puppet/r10k/keystone
+++ b/puppet/r10k/keystone
@@ -24,3 +24,5 @@ mod 'openstack/openstacklib',
 mod 'openstack/oslo',
     :git    => "https://github.com/openstack/puppet-oslo.git",
     :branch => "master"
+mod 'datacentred/dc_openstack',
+    :git => "https://github.com/datacentred/dc_openstack"


### PR DESCRIPTION
Enables the healthcheck middleware for glance, keystone and nova.

(There is no way to simply add a new item to the values so I had to take their existing contents and add the healthcheck manually to the beginning of the pipeline. That's why it's sooo long.)

PD-2185