### PR TITLE
[Nova] Fix NoVNC by using memcache to share tokens

### DIFF
--- a/puppet/hieradata/domains/sal01.datacentred.co.uk.yaml
+++ b/puppet/hieradata/domains/sal01.datacentred.co.uk.yaml
@@ -21,3 +21,8 @@ neutron_db_pass: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFM
 neutron_api_port: '9696'
 
 os_region_name: 'sal01'
+
+memcached_servers:
+ - osdbmq0.%{::domain}
+ - osdbmq1.%{::domain}
+ - osdbmq2.%{::domain}

--- a/puppet/hieradata/domains/sal01.datacentred.co.uk/modules/nova.yaml
+++ b/puppet/hieradata/domains/sal01.datacentred.co.uk/modules/nova.yaml
@@ -4,7 +4,7 @@ nova::rabbit_hosts:
  - osdbmq1.%{::domain}
  - osdbmq2.%{::domain}
 
-nova::keystone::authtoken::memcached_servers:
+nova::memcached_servers:
  - osdbmq0.%{::domain}
  - osdbmq1.%{::domain}
  - osdbmq2.%{::domain}

--- a/puppet/hieradata/domains/vagrant.test.yaml
+++ b/puppet/hieradata/domains/vagrant.test.yaml
@@ -26,3 +26,6 @@ neutron_db_pass:     'alNanJetOcs6'
 neutron_api_port:    '9696'
 
 os_region_name: 'vagrant'
+
+memcached_servers:
+ - osdbmq0.%{::domain}

--- a/puppet/hieradata/domains/vagrant.test/modules/nova.yaml
+++ b/puppet/hieradata/domains/vagrant.test/modules/nova.yaml
@@ -2,8 +2,7 @@
 nova::rabbit_host: osdbmq0.%{::domain}
 nova::rabbit_ha_queues: false
 
-nova::keystone::authtoken::memcached_servers:
- - osdbmq0.%{::domain}
+nova::memcached_servers: osdbmq0.%{::domain}
 
 nova::api::osapi_compute_workers: '1'
 nova::api::metadata_workers: '1'

--- a/puppet/modules/profile/manifests/openstack/nova.pp
+++ b/puppet/modules/profile/manifests/openstack/nova.pp
@@ -22,6 +22,7 @@ class profile::openstack::nova {
     'keystone_authtoken/project_name':        value => 'services';
     'keystone_authtoken/username':            value => 'nova';
     'keystone_authtoken/password':            value => hiera('keystone_nova_password');
+    'DEFAULT/memcached_servers':              value => join(hiera('memcached_servers'), ',');
   }
 
   package { 'iptables':


### PR DESCRIPTION
This commit includes the necessary configuration for Nova's novncproxy
to use memcache for token caching so that the console works regardless
of which control node you hit.

It also correctly scopes the other Keystone related memcache
configuration so that this is properly used.