### PR TITLE
[Nova] Ensure secure_proxy_ssl_header is set to pickup right protocol

### DIFF
--- a/puppet/hieradata/modules/nova.yaml
+++ b/puppet/hieradata/modules/nova.yaml
@@ -40,8 +40,6 @@ nova::api::sync_db_api: false
 nova::api::enable_instance_password: true
 nova::api::neutron_metadata_proxy_shared_secret: "%{hiera('neutron_metadata_secret')}"
 nova::api::default_floating_pool: 'external'
-nova::api::secure_proxy_ssl_header: 'X-Forwarded-Proto'
-nova::api::compute_link_prefix: 'https://compute.datacentred.io:8774/'
 nova::api::admin_password: "%{hiera('keystone_nova_password')}"
 nova::api::auth_uri: "https://%{hiera('os_api_host')}:5000/"
 nova::api::identity_uri: "https://%{hiera('os_api_host')}:35357/"

--- a/puppet/modules/profile/manifests/openstack/nova.pp
+++ b/puppet/modules/profile/manifests/openstack/nova.pp
@@ -15,14 +15,15 @@ class profile::openstack::nova {
   # TODO: Remove these hacky workarounds once we're at a version of OpenStack that's
   # properly supported by puppet-nova
   nova_config {
-    'keystone_authtoken/auth_url':            value => "https://${hiera('os_api_host')}:35357";
-    'keystone_authtoken/auth_plugin':         value => 'password';
-    'keystone_authtoken/project_domain_name': value => 'default';
-    'keystone_authtoken/user_domain_name':    value => 'default';
-    'keystone_authtoken/project_name':        value => 'services';
-    'keystone_authtoken/username':            value => 'nova';
-    'keystone_authtoken/password':            value => hiera('keystone_nova_password');
-    'DEFAULT/memcached_servers':              value => join(hiera('memcached_servers'), ',');
+    'keystone_authtoken/auth_url':             value => "https://${hiera('os_api_host')}:35357";
+    'keystone_authtoken/auth_plugin':          value => 'password';
+    'keystone_authtoken/project_domain_name':  value => 'default';
+    'keystone_authtoken/user_domain_name':     value => 'default';
+    'keystone_authtoken/project_name':         value => 'services';
+    'keystone_authtoken/username':             value => 'nova';
+    'keystone_authtoken/password':             value => hiera('keystone_nova_password');
+    'DEFAULT/memcached_servers':               value => join(hiera('memcached_servers'), ',');
+    'oslo_middleware/secure_proxy_ssl_header': value => 'X-Forwarded-Proto';
   }
 
   package { 'iptables':


### PR DESCRIPTION
Although this was previously set in Hiera and scoped to the right class,
it's not being picked up for some reason.  Explicitly define it in the
profile class instead.

Remove the 'compute_link_prefix' option which has been deprecated.

🐛 for of PD-3011.