### PR TITLE
Switch to upstream puppet-horizon + improvements:

### DIFF
--- a/puppet/hieradata/modules/horizon.yaml
+++ b/puppet/hieradata/modules/horizon.yaml
@@ -30,3 +30,5 @@ horizon::default_theme: 'datacentred'
 horizon::images_panel: 'angular'
 horizon::log_handler: 'console'
 horizon::password_retrieve: true
+horizon::enable_user_pass: false
+horizon::root_path: '/usr/share/openstack-dashboard/openstack_dashboard'

--- a/puppet/r10k/horizon
+++ b/puppet/r10k/horizon
@@ -15,7 +15,7 @@ mod 'datacentred/branding',
     :branch => "mitaka-location-fix"
 
 mod 'openstack/horizon',
-    :git    => "https://github.com/datacentred/puppet-horizon.git",
+    :git    => "https://github.com/openstack/puppet-horizon.git",
     :branch => "master"
 
 mod 'openstack/openstacklib',


### PR DESCRIPTION
This commit replaces our `puppet-horizon` fork with the upstream one, so we
can use the latest improvements to the Horizon config:
* the password field is now removed from the Heat stack creation wizard;
* the path to our theme is now being set correctly in the Apache config.

Things I tested using a test container pointing to the Production APIs:
* the theme is displayed correctly;
* all look good when navigating the UI;
* launching an instance works fine;
* launching a Heat stack works as expected (the password field is gone).

In the long run, we should modify the branding repo, so the path is a local
variable and we can override it in hiera, but it makes more sense to address
this during the upcoming upgrade of this container to Newton.