### PR TITLE
[Nova] Bump the memory allocation ratio

### DIFF
--- a/puppet/hieradata/modules/nova.yaml
+++ b/puppet/hieradata/modules/nova.yaml
@@ -78,7 +78,7 @@ nova::scheduler::filter::scheduler_default_filters:
   - ServerGroupAntiAffinityFilter
   - ServerGroupAffinityFilter
   - IsolatedHostsFilter
-nova::scheduler::filter::ram_allocation_ratio: 0.9
+nova::scheduler::filter::ram_allocation_ratio: 1.0
 nova::scheduler::filter::cpu_allocation_ratio: 8.0
 nova::scheduler::filter::scheduler_host_subset_size: '10'
 


### PR DESCRIPTION
Increase this from slightly undercommitting at 0.9 to 1.0, which is
still down from the default of 1.5.

This value should be revisited once all nova-compute agents have been
upgraded to Liberty.

🐛 PD-3021.