### PR TITLE
[Neutron] Re-align container configuration with Production

### DIFF
--- a/puppet/hieradata/modules/neutron.yaml
+++ b/puppet/hieradata/modules/neutron.yaml
@@ -59,7 +59,8 @@ neutron::server::notifications::nova_admin_password: "%{hiera('keystone_nova_pas
 neutron::server::notifications::nova_region_name: "%{hiera('os_region_name')}"
 neutron::server::notifications::auth_plugin: 'password'
 
-neutron::server::allow_automatic_l3agent_failover: true
+neutron::server::allow_automatic_l3agent_failover: false
+neutron::server::allow_automatic_dhcp_failover: false
 neutron::server::max_l3_agents_per_router: '2'
 neutron::server::min_l3_agents_per_router: '2'
 neutron::server::l3_ha: true

--- a/puppet/modules/profile/manifests/openstack/neutron.pp
+++ b/puppet/modules/profile/manifests/openstack/neutron.pp
@@ -13,15 +13,16 @@ class profile::openstack::neutron {
   # TODO: Remove these hacky workarounds once we're at a version of OpenStack that's
   # properly supported by puppet-nova
   neutron_config {
-    'keystone_authtoken/auth_plugin':         value => 'password';
-    'keystone_authtoken/auth_url':            value => "https://${hiera('os_api_host')}:35357";
-    'keystone_authtoken/username':            value => 'neutron';
-    'keystone_authtoken/password':            value => hiera('keystone_neutron_password');
-    'keystone_authtoken/project_domain_name': value => 'default';
-    'keystone_authtoken/user_domain_name':    value => 'default';
-    'keystone_authtoken/project_name':        value => 'services';
-    'nova/project_domain_name':               value => 'default';
-    'nova/user_domain_name':                  value => 'default';
+    'keystone_authtoken/auth_plugin':                          value => 'password';
+    'keystone_authtoken/auth_url':                             value => "https://${hiera('os_api_host')}:35357";
+    'keystone_authtoken/username':                             value => 'neutron';
+    'keystone_authtoken/password':                             value => hiera('keystone_neutron_password');
+    'keystone_authtoken/project_domain_name':                  value => 'default';
+    'keystone_authtoken/user_domain_name':                     value => 'default';
+    'keystone_authtoken/project_name':                         value => 'services';
+    'nova/project_domain_name':                                value => 'default';
+    'nova/user_domain_name':                                   value => 'default';
+    'DEFAULT/enable_services_on_agents_with_admin_state_down': value => true;
   }
 
 }


### PR DESCRIPTION
Whilst updating the Neutron Server profile class I spotted a couple of other recently-added options that weren't handled in the Docker equivalent.

This commit should align the two and ensure consistency.