### PR TITLE
[Neutron] Additional Production configuration alignment

### DIFF
--- a/puppet/hieradata/modules/neutron.yaml
+++ b/puppet/hieradata/modules/neutron.yaml
@@ -11,6 +11,7 @@ neutron::service_plugins:
  - 'router'
  - 'firewall'
  - 'lbaas'
+ - 'vpnaas'
  - 'metering'
 neutron::verbose: true
 neutron::use_syslog: true
@@ -28,8 +29,9 @@ neutron::keystone::authtoken::project_domain_name: 'default'
 neutron::server::auth_uri: "https://%{hiera('os_api_host')}:5000/"
 neutron::server::identity_uri: "https://%{hiera('os_api_host')}:35357/"
 neutron::server::auth_password: "%{hiera('keystone_neutron_password')}"
-neutron::server::database_max_pool_size: '40'
-neutron::server::database_max_overflow: '20'
+neutron::server::database_max_pool_size: '200'
+neutron::server::database_max_overflow: '60'
+neutron::server::agent_down_time: '100'
 
 neutron::db::database_connection: "mysql://neutron:%{hiera('neutron_db_pass')}@%{hiera('os_api_host')}/neutron"
 
@@ -64,32 +66,6 @@ neutron::server::allow_automatic_dhcp_failover: false
 neutron::server::max_l3_agents_per_router: '2'
 neutron::server::min_l3_agents_per_router: '2'
 neutron::server::l3_ha: true
-
-neutron::agents::metadata::shared_secret: "%{hiera('neutron_metadata_secret')}"
-neutron::agents::metadata::auth_url: "https://%{hiera('os_api_host')}:35357/v2.0"
-neutron::agents::metadata::auth_password: "%{hiera('keystone_neutron_password')}"
-neutron::agents::metadata::auth_region: "%{hiera('os_region_name')}"
-neutron::agents::metadata::metadata_ip: "%{hiera('os_api_vip')}"
-
-neutron::agents::dhcp::enabled: true
-neutron::agents::dhcp::dhcp_delete_namespaces: true
-neutron::agents::dhcp::dhcp_domain: 'datacentred.io'
-
-neutron::agents::l3::manage_service: false
-neutron::agents::l3::enabled: true
-neutron::agents::l3::router_delete_namespaces: true
-neutron::agents::l3::interface_driver: 'neutron.agent.linux.interface.OVSInterfaceDriver'
-neutron::agents::l3::ha_enabled: true
-neutron::agents::l3::ha_vrrp_auth_password: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEATkyFfXMt3kXBU90OD0WDHscOtMINkC41NdJE6NCRkVw43bJKYikrjncMXcPkk3rrrYGS8Hob50vvGvpbjM2x38JjkbptdPZvFlUXlHwH3YjabnKlSns8Iqsq+ZrtV3+8BHGE9BUWJj+Ew5gNFJ81jEqnSy9f3oDKeuOaImxlfn+4LkI2KEWn5wpoX0BWX5z0Q5FFTEOo6K9w8mPzHr5OO1vogjcw6Ya0wmJlsAdkuZwv5e1taGgCv4lgdG+vwnsaB43qofsBBpEw9stdaKeiCMdrn2x1Ju7iu/SJPEBoyxuQdp1zBj46BebpkWte1PeZ6by6rucbv7H9BDrsn9tgcTA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCOD8dtVX3vVhxm4ClQVSmngBCjnFFVz7/YyhaNkjAKwZQ6]
-neutron::agents::l3::external_network_bridge: ''
-neutron::agents::l3::gateway_external_network_id: ''
-
-neutron::agents::vpnaas::enabled: false
-neutron::agents::lbaas::enabled: true
-neutron::agents::metering::enabled: true
-
-neutron::services::fwaas::enabled: true
-neutron::services::fwaas::driver: 'neutron.services.firewall.drivers.linux.iptables_fwaas.IptablesFwaasDriver'
 
 neutron::quota::quota_floatingip: '1'
 

--- a/puppet/modules/profile/manifests/openstack/neutron.pp
+++ b/puppet/modules/profile/manifests/openstack/neutron.pp
@@ -8,7 +8,7 @@ class profile::openstack::neutron {
   include ::neutron::plugins::ml2
   include ::neutron::quota
 
-  ensure_packages(['python-neutron-lbaas'])
+  ensure_packages(['python-neutron-lbaas','python-neutron-vpnaas'])
 
   # TODO: Remove these hacky workarounds once we're at a version of OpenStack that's
   # properly supported by puppet-nova


### PR DESCRIPTION
This commit updates the database pool configuration to align with recent
changes in Production, and re-introduces VPNaaS as we're not ready to
deprecate that entirely just yet.

It also deletes a bunch of data related to agent settings as these are
out of scope here and so never used.