### PR TITLE
[Neutron] Use default setting for agent_down_time

### DIFF
--- a/puppet/hieradata/modules/neutron.yaml
+++ b/puppet/hieradata/modules/neutron.yaml
@@ -31,7 +31,6 @@ neutron::server::identity_uri: "https://%{hiera('os_api_host')}:35357/"
 neutron::server::auth_password: "%{hiera('keystone_neutron_password')}"
 neutron::server::database_max_pool_size: '60'
 neutron::server::database_max_overflow: '20'
-neutron::server::agent_down_time: '100'
 
 neutron::db::database_connection: "mysql://neutron:%{hiera('neutron_db_pass')}@%{hiera('os_api_host')}/neutron"
 


### PR DESCRIPTION
Defaults and description as follows:

```
# Seconds to regard the agent is down; should be at least twice
# report_interval, to be sure the agent is down for good. (integer value)
 # agent_down_time = 75
```