### PR TITLE
[Workflow] Tag images with domain, minor cleanup, remove 'release'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 DOMAIN=sal01.datacentred.co.uk
 BASE='ubuntu:16.04'
-UBUNTU_CODENAME='xenial'
-RELEASE=mitaka
+DIST_CODENAME='xenial'
 VCSREF=$(shell git rev-parse --short HEAD)
 DATE=$(shell date --rfc-3339=date)
 REGISTRY=registry.datacentred.services:5000
@@ -12,39 +11,40 @@ all:	keystone glance cinder horizon nova
 keystone:
 		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
 		rocker build --no-cache -f common/Rockerfile --vars common/common.yaml --var EXPOSE="5000 35357" \
-		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
-		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(VCSREF) $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
 
 glance:
 		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
 		rocker build --no-cache -f common/Rockerfile --vars common/common.yaml --var EXPOSE="9191 9292" \
-		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
-		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(VCSREF) $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
 
 cinder:
 		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
 		rocker build --no-cache -f common/Rockerfile --vars common/common.yaml --var EXPOSE="8776" \
-		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
-		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(VCSREF) $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
 
 nova:
 		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
 		rocker build --no-cache -f common/Rockerfile --vars common/common.yaml --var EXPOSE="8774 8775" \
-		--var BASE=$(BASE) --var UBUNTU_CODENAME=$(UBUNTU_CODENAME) \
-		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
-		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+		--var BASE=$(BASE) --var DIST_CODENAME=$(DIST_CODENAME) \
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(VCSREF) $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+
 neutron:
 		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
 		rocker build --no-cache -f common/Rockerfile --vars common/common.yaml --var EXPOSE="9696" \
-		--var BASE=$(BASE) --var UBUNTU_CODENAME=$(UBUNTU_CODENAME) \
-		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
-		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+		--var BASE=$(BASE) --var DIST_CODENAME=$(DIST_CODENAME) \
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(VCSREF) $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
 
 horizon:
 		NAME=$@ DATE=$(DATE) VCSREF=$(VCSREF) \
 		rocker build --no-cache -f common/Rockerfile --vars common/common.yaml --var EXPOSE="80" \
-		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(RELEASE)-$(VCSREF) --var ROLE=$@ .
-		docker tag $@:$(RELEASE)-$(VCSREF) $(REGISTRY)/$@:$(RELEASE)-$(VCSREF)
+		--var DOCKER_BUILD_DOMAIN=$(DOMAIN) --var TAG=$@:$(VCSREF) --var ROLE=$@ .
+		docker tag $@:$(VCSREF) $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
 
 clean:
 		yes | docker image prune

--- a/common/Rockerfile
+++ b/common/Rockerfile
@@ -4,7 +4,7 @@ MAINTAINER {{ .MAINTAINER }}
 ENV DOCKER_BUILD_DOMAIN={{ .DOCKER_BUILD_DOMAIN }}
 ENV FACTER_role={{ .ROLE }} FACTER_domain=${DOCKER_BUILD_DOMAIN:-vagrant.test}
 ENV PUPPET_AGENT_VERSION={{ .PUPPET_AGENT_VERSION }}
-ENV UBUNTU_CODENAME={{ .UBUNTU_CODENAME }}
+ENV DIST_CODENAME={{ .DIST_CODENAME }}
 ENV PATH={{ .PATH }}
 
 MOUNT {{ .MOUNT.puppet }}
@@ -26,6 +26,9 @@ EXPOSE {{ .EXPOSE }}
 
 LABEL org.label-schema.build-date={{ .Env.DATE }} \
       org.label-schema.name={{ .Env.NAME }} \
+      {{ if .Env.RELEASE }}
+        org.label-schema.release={{ .Env.RELEASE }} \
+      {{ end }}
       org.label-schema.vcs-ref={{ .Env.VCSREF }} \
       org.label-schema.vcs-url="https://github.com/datacentred/docker"
 

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -3,7 +3,7 @@ MAINTAINER: 'devops@datacentred.co.uk'
 
 DOCKER_BUILD_DOMAIN: 'sal01.datacentred.co.uk'
 PUPPET_AGENT_VERSION: '1.8.2'
-UBUNTU_CODENAME: 'xenial'
+DIST_CODENAME: 'xenial'
 PATH: '/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH'
 MOUNT:
   puppet: '/opt/puppetlabs /etc/puppetlabs /root/.gem'
@@ -14,11 +14,11 @@ RUN:
   puppet_install: |
     apt-get update && \
     apt-get install -y lsb-release inetutils-ping vim git wget && \
-    wget https://apt.puppetlabs.com/puppetlabs-release-pc1-"$UBUNTU_CODENAME".deb && \
-    dpkg -i puppetlabs-release-pc1-"$UBUNTU_CODENAME".deb && \
-    rm puppetlabs-release-pc1-"$UBUNTU_CODENAME".deb && \
+    wget https://apt.puppetlabs.com/puppetlabs-release-pc1-"$DIST_CODENAME".deb && \
+    dpkg -i puppetlabs-release-pc1-"$DIST_CODENAME".deb && \
+    rm puppetlabs-release-pc1-"$DIST_CODENAME".deb && \
     apt-get update && \
-    apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$UBUNTU_CODENAME" && \
+    apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$DIST_CODENAME" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
   install_gems: '/opt/puppetlabs/puppet/bin/gem install hiera-eyaml deep_merge r10k:2.2.2 --no-ri --no-rdoc'


### PR DESCRIPTION
This commit tags images with the domain for which they're built, thus
allowing us to push non-Production images into our Production registry
without causing conflict / confusion.

It also removes the 'release' that's part of the image tag as it's
arbitrary and often confusing.  This can still be optionally added to
the image metadata at time of build and inspected with something like:

```
$ docker inspect 85eaf31aa48f | jq '.[0] | .Config.Labels'
{
  "org.label-schema.build-date": "1705",
  "org.label-schema.name": "keystone",
  "org.label-schema.release": "mitaka",
  "org.label-schema.vcs-ref": "801da91",
  "org.label-schema.vcs-url": "https://github.com/datacentred/docker"
}
```

♻ and 🔧 part of  PD-3016.