### PR TITLE
Update the prompt profile class to reflect refactor

### DIFF
--- a/modules/profile/manifests/util/prompt.pp
+++ b/modules/profile/manifests/util/prompt.pp
@@ -8,6 +8,6 @@ class profile::util::prompt {
     owner   => root,
     group   => root,
     mode    => '0644',
-    content => $::role,
+    content => $::node,
   }
 }


### PR DESCRIPTION
The prompt profile utility class references a top-level fact that's
changed (role is now node).  Update this so that the prompt is prefixed
appropriately.