### PR TITLE
Enable publishing notifications from Neutron:

### DIFF
--- a/modules/profile/manifests/openstack/neutron.pp
+++ b/modules/profile/manifests/openstack/neutron.pp
@@ -25,6 +25,7 @@ class profile::openstack::neutron {
     'DEFAULT/enable_services_on_agents_with_admin_state_down': value => true;
     'DEFAULT/executor_thread_pool_size':                       value => '2048';
     'DEFAULT/rpc_conn_pool_size':                              value => '60';
+    'DEFAULT/notification_driver':                             value => 'messagingv2';
   }
 
 }


### PR DESCRIPTION
The `notification_driver` parameter was not set (defaults to an empty list) and
as a result notifications from Neutron were not published to Rabbit.
This commit sets add the missing parameter.