### PR TITLE
[Workflow] Automatically push built images, add missing modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PUSH=false
 DOMAIN=sal01.datacentred.co.uk
 VCSREF=$(shell git rev-parse --short HEAD)
 REGISTRY=registry.datacentred.services:5000
@@ -7,36 +8,43 @@ PDB=puppet docker build --rocker --label-schema \
 		--factfile=env/$(DOMAIN).txt \
 		--image-name $@
 
-all:	keystone glance cinder horizon nova neutron telemetry
-.PHONY: all keystone glance cinder horizon nova neutron telemetry clean
+all:		all keystone glance cinder horizon nova neutron telemetry clean
+.PHONY:	all keystone glance cinder horizon nova neutron telemetry clean
 
 keystone:
-		$(PDB) --expose=5000,35357
-		docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	$(PDB) --expose=5000,35357
+	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 
 glance:
-		$(PDB) --expose=9191,9292
-		docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	$(PDB) --expose=9191,9292
+	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 
 cinder:
-		$(PDB) --expose=8776
-		docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	$(PDB) --expose=8776
+	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 
 nova:
-		$(PDB) --expose=8774,8775 --from ubuntu:14.04
-		docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	$(PDB) --expose=8774,8775 --from ubuntu:14.04
+	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 
 neutron:
-		$(PDB) --expose=9696 --from ubuntu:14.04
-		docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	$(PDB) --expose=9696 --from ubuntu:14.04
+	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 
 horizon:
-		$(PDB) --expose=80
-		docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	$(PDB) --expose=80
+	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 
 telemetry:
-		$(PDB) --expose=8042,8777
-		docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	$(PDB) --expose=8042,8777
+	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 
 clean:
-		yes | docker image prune
+	yes | docker image prune

--- a/Puppetfile
+++ b/Puppetfile
@@ -11,6 +11,8 @@ mod 'puppetlabs/concat', '1.2.5'
 mod 'puppetlabs-dummy_service', '0.2.0'
 mod 'puppetlabs/inifile'
 mod 'puppetlabs/mysql'
+mod 'openstack-vswitch'
+mod 'duritong-sysctl'
 mod 'openstack-nova', '8.0.1'
 mod 'puppet/staging'
 mod 'rmueller/cron'
@@ -19,6 +21,10 @@ mod 'puppetlabs/postgresql'
 
 mod 'openstack/glance',
     :git    => "https://github.com/openstack/puppet-glance",
+    :branch => "master"
+
+mod 'openstack/horizon',
+    :git    => "https://github.com/openstack/puppet-horizon",
     :branch => "master"
 
 mod 'openstack/cinder',
@@ -53,3 +59,6 @@ mod 'spjmurray/ceph', '1.5.1'
 
 mod 'datacentred/dc_openstack',
     :git => "https://github.com/datacentred/dc_openstack"
+
+mod 'datacentred/branding',
+    :git => "https://github.com/datacentred/branding.git"


### PR DESCRIPTION
If the $PUSH environment variable is set to true, attempt to push the
built image to our private registry.

Also updates the `Puppetfile` to include a few missing dependancies.

🔧 PD-3016.