### PR TITLE
[Workflow] Set the default shell for 'make' to be 'bash'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL:=/usr/bin/env bash
+
 PUSH=false
 DOMAIN=sal01.datacentred.co.uk
 VCSREF=$(shell git rev-parse --short HEAD)


### PR DESCRIPTION
This wasn't caught in local testing as it seems that the behaviour under
MacOS is to use $SHELL.  Otherwise, by default 'make' uses '/bin/sh'
which doesn't like the "bashisms" in this Makefile.