### PR TITLE
Remove Aodh from behind Apache

### DIFF
--- a/hieradata/modules/aodh.yaml
+++ b/hieradata/modules/aodh.yaml
@@ -25,14 +25,8 @@ aodh::auth::auth_type: 'password'
 aodh::api::enabled: true # default
 aodh::api::manage_service: false
 aodh::api::port: "%{hiera('aodh_port')}"
-aodh::api::service_name: 'httpd'
 aodh::api::sync_db: false
 aodh::api::auth_strategy: 'keystone # default'
-
-aodh::wsgi::apache::servername: "%{::fqdn}" # default
-aodh::wsgi::apache::port: "%{hiera('aodh_port')}"
-aodh::wsgi::apache::ssl: false
-aodh::wsgi::apache::priority: '10' # default
 
 # Replaces ceilometer's alarm_history_time_to_live
 aodh::alarm_history_time_to_live: '86401'

--- a/hieradata/nodes/telemetry.yaml
+++ b/hieradata/nodes/telemetry.yaml
@@ -5,11 +5,11 @@ classes:
 
 service:
   'aodh-api':
-    'command': '/usr/sbin/apachectl -DFOREGROUND'
     'stdout_logfile': '/dev/stdout'
     'stderr_logfile': '/dev/stderr'
     'stdout_logfile_maxbytes': '0'
     'stderr_logfile_maxbytes': '0'
+    'command': '/usr/bin/aodh-api'
   'aodh-evaluator':
     'stdout_logfile': '/dev/stdout'
     'stderr_logfile': '/dev/stderr'

--- a/modules/profile/manifests/openstack/aodh.pp
+++ b/modules/profile/manifests/openstack/aodh.pp
@@ -7,22 +7,6 @@ class profile::openstack::aodh {
   include ::aodh::evaluator
   include ::aodh::listener
   include ::aodh::notifier
-  include ::aodh::wsgi::apache
   include ::aodh::config
-
-  file { '/var/log/apache2/aodh_wsgi_access.log':
-    target  => '/dev/stdout',
-    require => Package['httpd'],
-  }
-
-  file { '/var/log/apache2/aodh_wsgi_error.log':
-    target  => '/dev/stderr',
-    require => Package['httpd'],
-  }
-
-  file { '/var/log/apache2/error.log':
-    target  => '/dev/stderr',
-    require => Package['httpd'],
-  }
 
 }

--- a/modules/profile/manifests/openstack/ceilometer.pp
+++ b/modules/profile/manifests/openstack/ceilometer.pp
@@ -25,6 +25,11 @@ class profile::openstack::ceilometer {
     require => Package['httpd'],
   }
 
+  file { '/var/log/apache2/error.log':
+    target  => '/dev/stderr',
+    require => Package['httpd'],
+  }
+
   file { '/etc/ceilometer/event_definitions.yaml':
     ensure  => present,
     content => file('dc_openstack/event_definitions.yaml'),


### PR DESCRIPTION
This configures `aodh-api` as a service independent from Apache.

I've left the default number of API workers (one per container) as this should
be enough for now, and the event API hack, as I want to address it later.