### PR TITLE
Aodh and Ceilometer in separate containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,13 @@ horizon:
 	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
 	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 
-telemetry:
-	$(PDB) --expose=8042,8777
+ceilometer:
+	$(PDB) --expose=8777
+	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
+	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
+
+aodh:
+	$(PDB) --expose=8042
 	docker tag $@ $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF)
 	@if [ $(PUSH) == true ]; then docker push $(REGISTRY)/$(DOMAIN)/$@:$(VCSREF) ; fi
 

--- a/hieradata/nodes/aodh.yaml
+++ b/hieradata/nodes/aodh.yaml
@@ -1,0 +1,34 @@
+---
+classes:
+  - '::profile::openstack::aodh'
+
+service:
+  'aodh-api':
+    'command': '/usr/sbin/apachectl -DFOREGROUND'
+    'stdout_logfile': '/dev/stdout'
+    'stderr_logfile': '/dev/stderr'
+    'stdout_logfile_maxbytes': '0'
+    'stderr_logfile_maxbytes': '0'
+  'aodh-evaluator':
+    'stdout_logfile': '/dev/stdout'
+    'stderr_logfile': '/dev/stderr'
+    'stdout_logfile_maxbytes': '0'
+    'stderr_logfile_maxbytes': '0'
+    'command': '/usr/bin/aodh-evaluator'
+  'aodh-listener':
+    'stdout_logfile': '/dev/stdout'
+    'stderr_logfile': '/dev/stderr'
+    'stdout_logfile_maxbytes': '0'
+    'stderr_logfile_maxbytes': '0'
+    'command': '/usr/bin/aodh-listener'
+  'aodh-notifier':
+    'stdout_logfile': '/dev/stdout'
+    'stderr_logfile': '/dev/stderr'
+    'stdout_logfile_maxbytes': '0'
+    'stderr_logfile_maxbytes': '0'
+    'command': '/usr/bin/aodh-notifier'
+
+aodh_db: 'aodh'         # default
+aodh_db_user: 'aodh'    # default
+aodh_port: 8042         # default
+#keystone_aodh_email: "devops@datacentred.co.uk"

--- a/hieradata/nodes/ceilometer.yaml
+++ b/hieradata/nodes/ceilometer.yaml
@@ -1,33 +1,8 @@
 ---
 classes:
-  - '::profile::openstack::aodh'
   - '::profile::openstack::ceilometer'
 
 service:
-  'aodh-api':
-    'command': '/usr/sbin/apachectl -DFOREGROUND'
-    'stdout_logfile': '/dev/stdout'
-    'stderr_logfile': '/dev/stderr'
-    'stdout_logfile_maxbytes': '0'
-    'stderr_logfile_maxbytes': '0'
-  'aodh-evaluator':
-    'stdout_logfile': '/dev/stdout'
-    'stderr_logfile': '/dev/stderr'
-    'stdout_logfile_maxbytes': '0'
-    'stderr_logfile_maxbytes': '0'
-    'command': '/usr/bin/aodh-evaluator'
-  'aodh-listener':
-    'stdout_logfile': '/dev/stdout'
-    'stderr_logfile': '/dev/stderr'
-    'stdout_logfile_maxbytes': '0'
-    'stderr_logfile_maxbytes': '0'
-    'command': '/usr/bin/aodh-listener'
-  'aodh-notifier':
-    'stdout_logfile': '/dev/stdout'
-    'stderr_logfile': '/dev/stderr'
-    'stdout_logfile_maxbytes': '0'
-    'stderr_logfile_maxbytes': '0'
-    'command': '/usr/bin/aodh-notifier'
   'ceilometer-api':
     'command': '/usr/sbin/apachectl -DFOREGROUND'
     'stdout_logfile': '/dev/stdout'
@@ -52,11 +27,6 @@ service:
     'stdout_logfile_maxbytes': '0'
     'stderr_logfile_maxbytes': '0'
     'command': '/usr/bin/ceilometer-agent-notification'
-
-aodh_db: 'aodh'         # default
-aodh_db_user: 'aodh'    # default
-aodh_port: 8042         # default
-#keystone_aodh_email: "devops@datacentred.co.uk"
 
 ceilometer_db: 'ceilometer'         # default
 ceilometer_db_user: 'ceilometer'    # default

--- a/modules/profile/manifests/openstack/ceilometer.pp
+++ b/modules/profile/manifests/openstack/ceilometer.pp
@@ -25,6 +25,11 @@ class profile::openstack::ceilometer {
     require => Package['httpd'],
   }
 
+  file { '/var/log/apache2/error.log':
+    target  => '/dev/stderr',
+    require => Package['httpd'],
+  }
+
   file { '/etc/ceilometer/event_definitions.yaml':
     ensure  => present,
     content => file('dc_openstack/event_definitions.yaml'),
@@ -41,15 +46,6 @@ class profile::openstack::ceilometer {
     group   => 'root',
     mode    => '0644',
     require => Class['::ceilometer::agent::notification'],
-  }
-
-  file { '/usr/lib/python2.7/dist-packages/ceilometer/api/controllers/v2/events.py':
-      ensure  => present,
-      content => file('dc_openstack/events.py'),
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      require => Class['::ceilometer'],
   }
 
 }


### PR DESCRIPTION
Splits our Telemetry container into separate containers for both Aodh and
Ceilometer.

Also reverts the events API RBAC hack.

Addresses PD-3166