### PR TITLE
Tag Keystone with version supporting signing_dir

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -36,24 +36,24 @@ mod 'openstack/oslo',
     :branch => "master"
 
 mod 'openstack/keystone',
-    :git    => "https://github.com/openstack/puppet-keystone",
-    :branch => "master"
+    :git => "https://github.com/openstack/puppet-keystone",
+    :tag => "11.1.0"
 
 mod 'openstack/neutron',
     :git => "https://github.com/openstack/puppet-neutron",
     :tag => "liberty-eol"
 
 mod 'openstack/aodh',
-    :git    => "https://github.com/openstack/puppet-aodh",
-    :branch => "stable/newton"
+    :git => "https://github.com/openstack/puppet-aodh",
+    :tag => "9.5.0"
 
 mod 'openstack/ceilometer',
     :git    => "https://github.com/openstack/puppet-ceilometer",
     :branch => "master"
 
 mod 'openstack/heat',
-    :git    => "https://github.com/openstack/puppet-heat",
-    :tag    => "9.4.1"
+    :git => "https://github.com/openstack/puppet-heat",
+    :tag => "9.4.1"
 
 mod 'openstack/openstacklib',
     :git    => "https://github.com/openstack/puppet-openstacklib",

--- a/modules/profile/manifests/openstack/aodh.pp
+++ b/modules/profile/manifests/openstack/aodh.pp
@@ -2,7 +2,6 @@ class profile::openstack::aodh {
 
   include ::aodh
   include ::aodh::keystone::authtoken
-  include ::aodh::auth
   include ::aodh::api
   include ::aodh::evaluator
   include ::aodh::listener


### PR DESCRIPTION
Since this change:
https://github.com/openstack/puppet-keystone/commit/7dfc3cd0021b79e2be81da2ee4a5fc9954abc021
the `signing_dir` parameter is no longer available for Aodh (and
also for other modules not pointing to their master branch).

This commit pins puppet-keystone to the latest tag before the change. It
also replaces branch pinning with a tag pining for puppet-aodh and
removes unused aodh::auth class.

A long-term solution would be to bring Aodh's Puppet repo up-to-date,
but this require more testing.

Addresses: PD-3166