### PR TITLE
Update Horizon to Pike

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -65,4 +65,5 @@ mod 'datacentred/dc_openstack',
     :git => "https://github.com/datacentred/dc_openstack"
 
 mod 'datacentred/branding',
-    :git => "https://github.com/datacentred/branding.git"
+    :git => "https://github.com/datacentred/branding.git",
+    :branch => "master"

--- a/hieradata/modules/branding.yaml
+++ b/hieradata/modules/branding.yaml
@@ -1,2 +1,0 @@
----
-branding::horizon::release: 'mitaka'

--- a/hieradata/modules/horizon.yaml
+++ b/hieradata/modules/horizon.yaml
@@ -31,4 +31,5 @@ horizon::images_panel: 'angular'
 horizon::log_handler: 'console'
 horizon::password_retrieve: true
 horizon::enable_user_pass: false
-horizon::root_path: '/usr/share/openstack-dashboard/openstack_dashboard'
+horizon::root_path: '/var/lib/openstack-dashboard'
+horizon::help_url: 'https://docs.datacentred.io'

--- a/hieradata/nodes/horizon.yaml
+++ b/hieradata/nodes/horizon.yaml
@@ -10,6 +10,13 @@ service:
     'stdout_logfile_maxbytes': '0'
     'stderr_logfile_maxbytes': '0'
 
-branding::horizon::release: 'mitaka'
+apt::sources:
+  cloudarchive_mirror_pike:
+    location: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
+    release: 'xenial-updates/pike'
+    repos: 'main'
+    key:
+      id: '391A9AA2147192839E9DB0315EDB1B62EC4926EA'
+      server: 'keyserver.ubuntu.com'
 
 apache::mpm_module: 'event'


### PR DESCRIPTION
Allows to build a container with the Pike version of Horizon and the
newest iteration of our theme.

Also sets the `help_url` to point to our docs.

This PR:
https://github.com/datacentred/branding/pull/2
should to be merged first.

Part of PD-2992